### PR TITLE
Nixos support.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-BINDIR ?= /usr/local/bin
-LIBDIR ?= /usr/local/lib/oil
+BINDIR ?= /usr/bin
+LIBDIR ?= /usr/lib/oil
 
 .PHONY: install uninstall
 

--- a/src/oil
+++ b/src/oil
@@ -126,11 +126,11 @@ function searchAsYouType {
 }
 
 function formatColumns {
-	"$LIBDIR"/format-columns.awk
+        "$LD_LIBRARY_PATH"/format-columns.awk
 }
 
 function jsonToLine {
-	"$LIBDIR"/json-to-line.jq
+	"$LD_LIBRARY_PATH"/json-to-line.jq
 }
 
 function bookmarksAsJson {
@@ -194,7 +194,6 @@ function processBookmarks {
 }
 
 # globals
-LIBDIR=/usr/local/lib/oil
 mode="open"
 forceMultilineSelection=true
 declare -a selection


### PR DESCRIPTION
Made oil non-FHS compliant. The distro only now has to make sure that the LIBDIR variable is present on LD_LIBRARY_PATH and it all works out.

There should probably also have some sort of modification in the PKGBUILD for it to work again.

Thx!